### PR TITLE
extra containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Ops Manager and one MongoDB Agent (Make sure docker has access to **12G of RAM**
 ## Hints and tips:
 
 - Ops Manager needs 8G RAM to run reliably, an Agent 2.5G, so for Monitoring/Automation your looking at giving docker 10.5G
+- TLS certificates (testing use only) are available, please see [Enable TLS](/ops-manager/docs/tls-for-ops-manager.md) for more details
 - We also provide a couple of extra nodes called 
   - oplog (0.75G) `docker compose up -d oplog` (`oplog.om.internal`)
   - and blockstore (0.75G) `docker compose up -d blockstore` (`blockstore.om.internal`)
@@ -71,7 +72,7 @@ Ops Manager and one MongoDB Agent (Make sure docker has access to **12G of RAM**
   - `docker exec -it node1-om /bin/bash` runs bash as root on the **node1-om** container
   - you can just look at the docker-compose.yml to see what each container is called, or you can see it in `docker ps`
   - `docker stats` is a great way to see the cpu/memory usage and limits of each container 
-- TLS certificates (testing use only) are available, please see [Enable TLS](/ops-manager/docs/tls-for-ops-manager.md) for more details
+  - if you `cd extras` there are a couple of extra containers, one is a proxy (docker compose up -d proxy) on `proxy.om.interal` another is a load-balancer (docker compose up -d lb) on `lb.om.internal`
 
 ---
 
@@ -108,6 +109,7 @@ bash assets/x86_64_CM-agent.sh  # if your are on Intel Mac/Windows/Linux
 ---
 
 ## Changelog
+- 2024-04-23 Added working nginx loadbalancer and squid proxy
 - 2024-04-22 Single command needed to do everything, added oplog/blockstores/metadata with resonable sizes
 - 2024-04-16 Confirmed working on ARM/M1/Aaarch64, updated docs, set aarch64 as default as most users of this project (80%) are using M1's to run test environments
 - 2024-04-15 Make CM act more like the OM container, change container names so you can run OM/CM agents at the same time with no clash

--- a/ops-manager/build/Dockerfile-nginx-lb
+++ b/ops-manager/build/Dockerfile-nginx-lb
@@ -1,0 +1,3 @@
+FROM nginx
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/nginx.conf

--- a/ops-manager/docker-compose.yml
+++ b/ops-manager/docker-compose.yml
@@ -121,16 +121,45 @@ services:
       - ./mongodb-mms:/etc/mongodb-mms:ro
       - ./certs:/certs
 
-  squid:
+  proxy:
     image: diouxx/squid
     networks:
       main:
         aliases:
-          - squid.alt.internal
-    container_name: squid
-    hostname: squid.om.internal
+          - proxy.alt.internal
+    container_name: proxy
+    deploy:
+      resources:
+        limits:
+          cpus: '0.250'
+          memory: 0.5G
+        reservations:
+          cpus: '0.250'
+          memory: 0.5G
+    hostname: proxy.om.internal
     ports:
       - "3128:3128"
+    restart: always
+
+  lb:
+    build:
+      context: .
+      dockerfile: ./build/Dockerfile-nginx-lb
+    networks:
+      main: 
+        aliases:
+         - lb.alt.internal
+    container_name: lb.om.internal
+    deploy:
+      resources:
+        limits:
+          cpus: '0.250'
+          memory: 0.5G
+        reservations:
+          cpus: '0.250'
+          memory: 0.5G
+    ports: 
+      - "80:80"
     restart: always
 
 networks:

--- a/ops-manager/nginx.conf
+++ b/ops-manager/nginx.conf
@@ -1,0 +1,11 @@
+events {}
+http {
+  resolver 127.0.0.11 valid=10s ipv6=off;
+  server {
+    location / {
+      set $target ops.om.internal:8080;
+      proxy_pass http://$target;
+      proxy_set_header Forwarded "$proxy_add_x_forwarded_for";
+    }
+  }
+}


### PR DESCRIPTION
Its gets complex if these are in their own file with dns resolution and external networks, I feel like just keep them in one file for now is the easiest way, also avoids people typing correct commands, next to the wrong compose file