### PR TITLE
Add Minio S3 to support awssdkv2 and immutable backups

### DIFF
--- a/ops-manager/docker-compose.yml
+++ b/ops-manager/docker-compose.yml
@@ -300,5 +300,34 @@ services:
          - kimp
          - kmip.om.internal
     restart: unless-stopped
+
+  minio:
+    image: minio/minio:latest
+    container_name: minio
+    ports:
+      - "9000:9000"   # S3 API
+      - "9001:9001"   # Web console
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    volumes:
+      - ./minio-data:/data
+    command: server /data --console-address ":9001"
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '0.750'
+          memory: 0.5G
+        reservations:
+          cpus: '0.125'
+          memory: 0.125G    
+    networks:
+      main:
+        aliases:
+         - minio
+         - minio.om.internal
+         - minio.alt.internal
+         
 networks:
   main:


### PR DESCRIPTION
Testing Results of change
<img width="2480" height="306" alt="image" src="https://github.com/user-attachments/assets/ad4a58b8-6b25-4064-b1c9-9db4d823316e" />
Immutable snapshot created
<img width="2490" height="946" alt="image" src="https://github.com/user-attachments/assets/5851f540-f09c-414f-a996-7edc3ffafdfc" />
Spin up new Ops Manager environment, point to immutable snapshot store and can import the previously created snapshot into the new OM
<img width="2508" height="766" alt="image" src="https://github.com/user-attachments/assets/9205f621-f320-4ea1-a3ee-1c1198fcdcdf" />
The imported snapshot is available to use for restores